### PR TITLE
added url to osu user profile to !np response

### DIFF
--- a/osuCelebrity-model/src/main/java/me/reddev/osucelebrity/OsuResponses.java
+++ b/osuCelebrity-model/src/main/java/me/reddev/osucelebrity/OsuResponses.java
@@ -25,7 +25,7 @@ public class OsuResponses extends Responses {
   
   public static final String POSITION = "%s is position #%d in the queue.";
   public static final String NOT_IN_QUEUE = "%s is not in the queue.";
-  public static final String NOW_PLAYING = "%s is currently playing %s";
+  public static final String NOW_PLAYING = "%s (https://osu.ppy.sh/u/%d) is currently playing %s";
   
   /*
    * Spectate-cycle notifications

--- a/osuCelebrity-twitch/src/main/java/me/reddev/osucelebrity/twitch/TwitchIrcBot.java
+++ b/osuCelebrity-twitch/src/main/java/me/reddev/osucelebrity/twitch/TwitchIrcBot.java
@@ -277,7 +277,7 @@ public class TwitchIrcBot extends ListenerAdapter<PircBotX> implements Runnable 
     if (player != null && status != null && status.getType() == Type.PLAYING) {
       String formatted =
           String.format(OsuResponses.NOW_PLAYING, player.getPlayer().getUserName(),
-              status.getDetail());
+                  player.getPlayer().getUserId(), status.getDetail());
       Integer beatmapId = osu.getBeatmapId(status.getDetail());
       if (beatmapId != null) {
         formatted += " https://osu.ppy.sh/b/" + beatmapId; 


### PR DESCRIPTION
i'd thought it would be cool if you would be able to get the osu profile of the current user without having to type the username myself. Some ppl in twitch-chat seem to agree with me.

Also, since I have no clue how to (test)run this stuff myself, I probably broke the entire project ^^
