### PR TITLE
[WIP] Pircbotx 2.1 extravaganza

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ local.properties
 
 # Intellij
 */.idea/
+.idea/
 *.iml
 *.iws
 

--- a/osuCelebrity-model/src/main/java/me/reddev/osucelebrity/AbstractIrcBot.java
+++ b/osuCelebrity-model/src/main/java/me/reddev/osucelebrity/AbstractIrcBot.java
@@ -10,13 +10,14 @@ import org.slf4j.Logger;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
 
-public abstract class AbstractIrcBot extends ListenerAdapter<PircBotX> implements Runnable {
+public abstract class AbstractIrcBot extends ListenerAdapter implements Runnable {
   public static class PublicSocketBot extends PircBotX {
-    public PublicSocketBot(Configuration<? extends PircBotX> configuration) {
+    public PublicSocketBot(Configuration configuration) {
       super(configuration);
     }
-    
+
     @Override
     public Socket getSocket() {
       return super.getSocket();
@@ -25,7 +26,7 @@ public abstract class AbstractIrcBot extends ListenerAdapter<PircBotX> implement
 
   private PublicSocketBot bot;
   
-  protected abstract Configuration<PircBotX> getConfiguration() throws Exception;
+  protected abstract Configuration getConfiguration() throws Exception;
   
   protected abstract Logger getLog();
   
@@ -37,9 +38,13 @@ public abstract class AbstractIrcBot extends ListenerAdapter<PircBotX> implement
   public void run() {
     try {
       bot = new PublicSocketBot(getConfiguration());
-      
-      getLog().debug("Connecting to {} as {}", bot.getConfiguration().getServerHostname(),
-          bot.getConfiguration().getLogin());
+
+      // since new pircbotx has fancy stuff with multiple servers
+      // lets also do fancy with possible multiple servers
+      String server = bot.getConfiguration().getServers().stream()
+              .map(Configuration.ServerEntry::getHostname)
+              .collect(Collectors.joining(","));
+      getLog().debug("Connecting to [{}] as {}", server, bot.getConfiguration().getLogin());
       bot.startBot();
     } catch (Exception e) {
       getLog().error("IRC error", e);
@@ -67,15 +72,15 @@ public abstract class AbstractIrcBot extends ListenerAdapter<PircBotX> implement
   }
 
   @Override
-  public void onConnect(ConnectEvent<PircBotX> event) throws Exception {
+  public void onConnect(ConnectEvent event) throws Exception {
     connectLatch.countDown();
-    getLog().debug("Connected to {} as {}", bot.getConfiguration().getServerHostname(),
+    getLog().debug("Connected to {} as {}", bot.getServerHostname(),
           bot.getConfiguration().getLogin());
   }
 
   @Override
-  public void onDisconnect(DisconnectEvent<PircBotX> event) throws Exception {
-    getLog().debug("Disconnected from {}", bot.getConfiguration().getServerHostname());
+  public void onDisconnect(DisconnectEvent event) throws Exception {
+    getLog().debug("Disconnected from {}", bot.getServerHostname());
   }
   
   public void awaitConnect() throws InterruptedException {

--- a/osuCelebrity-osu/src/main/java/me/reddev/osucelebrity/osu/OsuIrcBot.java
+++ b/osuCelebrity-osu/src/main/java/me/reddev/osucelebrity/osu/OsuIrcBot.java
@@ -43,7 +43,6 @@ import me.reddev.osucelebrity.twitch.TwitchUser;
 import org.apache.commons.lang3.tuple.Pair;
 import org.pircbotx.Configuration;
 import org.pircbotx.Configuration.Builder;
-import org.pircbotx.PircBotX;
 import org.pircbotx.hooks.events.JoinEvent;
 import org.pircbotx.hooks.events.PrivateMessageEvent;
 import org.pircbotx.hooks.events.QuitEvent;
@@ -77,13 +76,13 @@ import javax.jdo.PersistenceManagerFactory;
 public class OsuIrcBot extends AbstractIrcBot {
   @FunctionalInterface
   interface CommandHandler {
-    boolean handle(PrivateMessageEvent<PircBotX> event, String message, OsuUser user,
+    boolean handle(PrivateMessageEvent event, String message, OsuUser user,
         PersistenceManager pm) throws UserException, IOException, InterruptedException;
   }
 
   @FunctionalInterface
   interface ConfirmedCommandHandler {
-    void handle(PrivateMessageEvent<PircBotX> event, String message, OsuUser user,
+    void handle(PrivateMessageEvent event, String message, OsuUser user,
         PersistenceManager pm) throws UserException, IOException, InterruptedException;
   }
   
@@ -124,14 +123,15 @@ public class OsuIrcBot extends AbstractIrcBot {
   }
   
   @Override
-  protected Configuration<PircBotX> getConfiguration() {
-    Builder<PircBotX> configBuilder =
-        new Configuration.Builder<PircBotX>()
+  protected Configuration getConfiguration() {
+    Builder configBuilder =
+        new Configuration.Builder()
             .setName(ircSettings.getOsuIrcUsername())
             .setLogin(ircSettings.getOsuIrcUsername())
             .addListener(this)
-            .setServer(ircSettings.getOsuIrcHost(), ircSettings.getOsuIrcPort(),
-                ircSettings.getOsuIrcPassword()).setAutoReconnect(true).setMessageDelay(500);
+            .addServer(ircSettings.getOsuIrcHost(), ircSettings.getOsuIrcPort())
+            .setServerPassword(ircSettings.getOsuIrcPassword())
+            .setAutoReconnect(true).setMessageDelay(500);
     Stream.of(ircSettings.getOsuIrcAutoJoin().split(",")).forEach(
         configBuilder::addAutoJoinChannel);
     return configBuilder.buildConfiguration();
@@ -155,7 +155,7 @@ public class OsuIrcBot extends AbstractIrcBot {
   // http://site.pircbotx.googlecode.com/hg-history/2.0.1/apidocs/index.html
 
   @Override
-  public void onPrivateMessage(PrivateMessageEvent<PircBotX> event) {
+  public void onPrivateMessage(PrivateMessageEvent event) {
     if (event.getUser().getNick().equals(ircSettings.getOsuCommandUser())) {
       handleBanchoBotResponse(event.getMessage());
       return;
@@ -263,7 +263,7 @@ public class OsuIrcBot extends AbstractIrcBot {
     };
   }
   
-  void handleQueue(PrivateMessageEvent<PircBotX> event, String queueTarget, OsuUser user,
+  void handleQueue(PrivateMessageEvent event, String queueTarget, OsuUser user,
       PersistenceManager pm) throws IOException, UserException {
     // Permits: !spec username : reason
     // Example: !spec Tillerino: for awesomeness Keepo
@@ -278,7 +278,7 @@ public class OsuIrcBot extends AbstractIrcBot {
         msg -> respond(event, msg), msg -> respond(event, msg));
   }
 
-  void handleQueueSilent(PrivateMessageEvent<PircBotX> event, String queueTarget, OsuUser user,
+  void handleQueueSilent(PrivateMessageEvent event, String queueTarget, OsuUser user,
       PersistenceManager pm) throws IOException, UserException {
     if (!user.getPrivilege().canSkip) {
       throw new UserException(UNAUTHORIZED);
@@ -294,7 +294,7 @@ public class OsuIrcBot extends AbstractIrcBot {
         msg -> respond(event, msg));
   }
 
-  void handleSpec(PrivateMessageEvent<PircBotX> event, String message, OsuUser user,
+  void handleSpec(PrivateMessageEvent event, String message, OsuUser user,
       PersistenceManager pm) throws UserException, IOException {
     if (!user.getPrivilege().canSkip) {
       throw new UserException(UNAUTHORIZED);
@@ -308,7 +308,7 @@ public class OsuIrcBot extends AbstractIrcBot {
     }
   }
 
-  void handleSelfQueue(PrivateMessageEvent<PircBotX> event, String message, OsuUser user,
+  void handleSelfQueue(PrivateMessageEvent event, String message, OsuUser user,
       PersistenceManager pm) throws IOException {
     QueuedPlayer queueRequest = new QueuedPlayer(user, QueueSource.OSU, clock.getTime());
     EnqueueResult result =
@@ -320,7 +320,7 @@ public class OsuIrcBot extends AbstractIrcBot {
     }
   }
 
-  void handleSkip(PrivateMessageEvent<PircBotX> event, String message, OsuUser user,
+  void handleSkip(PrivateMessageEvent event, String message, OsuUser user,
       PersistenceManager pm) throws UserException, IOException {
     if (!user.getPrivilege().canSkip) {
       throw new UserException(UNAUTHORIZED);
@@ -332,7 +332,7 @@ public class OsuIrcBot extends AbstractIrcBot {
     }
   }
   
-  boolean handleMute(PrivateMessageEvent<PircBotX> event, String message, OsuUser user,
+  boolean handleMute(PrivateMessageEvent event, String message, OsuUser user,
       PersistenceManager pm) throws UserException, IOException {
     if (message.equalsIgnoreCase(MUTE)) {
       user.setAllowsNotifications(false);
@@ -347,7 +347,7 @@ public class OsuIrcBot extends AbstractIrcBot {
     return false;
   }
   
-  boolean handleOpt(PrivateMessageEvent<PircBotX> event, String message, OsuUser user,
+  boolean handleOpt(PrivateMessageEvent event, String message, OsuUser user,
       PersistenceManager pm) throws UserException, IOException {
     if (message.equalsIgnoreCase(OPTOUT)) {
       user.setAllowsSpectating(false);
@@ -368,7 +368,7 @@ public class OsuIrcBot extends AbstractIrcBot {
     return false;
   }
   
-  void handlePosition(PrivateMessageEvent<PircBotX> event, String message, OsuUser user,
+  void handlePosition(PrivateMessageEvent event, String message, OsuUser user,
       PersistenceManager pm) throws UserException, IOException {
     OsuUser requestedUser = osuApi.getUser(message, pm, 60 * 60 * 1000);
     if (requestedUser == null) {
@@ -385,7 +385,7 @@ public class OsuIrcBot extends AbstractIrcBot {
     }
   }
   
-  void handleSelfPosition(PrivateMessageEvent<PircBotX> event, String message, OsuUser user,
+  void handleSelfPosition(PrivateMessageEvent event, String message, OsuUser user,
       PersistenceManager pm) throws UserException, IOException {
     int position = spectator.getQueuePosition(pm, user);
     if (position != -1) {
@@ -397,7 +397,7 @@ public class OsuIrcBot extends AbstractIrcBot {
     }
   }
   
-  void handleGameMode(PrivateMessageEvent<PircBotX> event, String message, OsuUser user,
+  void handleGameMode(PrivateMessageEvent event, String message, OsuUser user,
       PersistenceManager pm) throws UserException, IOException {
     if (message.equalsIgnoreCase("osu")) {
       user.setGameMode(GameModes.OSU);
@@ -414,7 +414,7 @@ public class OsuIrcBot extends AbstractIrcBot {
     respond(event, Responses.GAME_MODE_CHANGED);
   }
   
-  void handleRestartClient(PrivateMessageEvent<PircBotX> event, String message, OsuUser user,
+  void handleRestartClient(PrivateMessageEvent event, String message, OsuUser user,
       PersistenceManager pm) throws UserException, IOException, InterruptedException {
     if (!user.getPrivilege().canRestartClient) {
       throw new UserException(UNAUTHORIZED);
@@ -423,7 +423,7 @@ public class OsuIrcBot extends AbstractIrcBot {
     osu.restartClient();
   }
   
-  void handleMod(PrivateMessageEvent<PircBotX> event, String message, OsuUser user,
+  void handleMod(PrivateMessageEvent event, String message, OsuUser user,
       PersistenceManager pm) throws UserException, IOException, InterruptedException {
     if (!user.getPrivilege().canMod) {
       throw new UserException(UNAUTHORIZED);
@@ -438,7 +438,7 @@ public class OsuIrcBot extends AbstractIrcBot {
     respond(event, "modded");
   }
   
-  void handleLink(PrivateMessageEvent<PircBotX> event, String message, OsuUser user,
+  void handleLink(PrivateMessageEvent event, String message, OsuUser user,
       PersistenceManager pm) throws UserException, IOException {
     final TwitchUser userObject =
         JdoQueryUtil.getUnique(pm, twitchUser, twitchUser.linkString.eq(message)).orElseThrow(
@@ -465,7 +465,7 @@ public class OsuIrcBot extends AbstractIrcBot {
   }
 
   @Override
-  public void onJoin(JoinEvent<PircBotX> event) {
+  public void onJoin(JoinEvent event) {
     // Ask for subscription and admin information
     if (event.getUser().getNick().equalsIgnoreCase(ircSettings.getOsuIrcUsername())) {
       log.info(String.format("Joined %s", event.getChannel().getName()));
@@ -474,12 +474,12 @@ public class OsuIrcBot extends AbstractIrcBot {
   }
 
   @Override
-  public void onQuit(QuitEvent<PircBotX> event) throws Exception {
+  public void onQuit(QuitEvent event) throws Exception {
     onlineUsers.remove(event.getUser().getNick());
   }
 
   @Override
-  public void onServerResponse(ServerResponseEvent<PircBotX> event) throws Exception {
+  public void onServerResponse(ServerResponseEvent event) throws Exception {
     if (event.getCode() == 353) {
       ImmutableList<String> parsedResponse = event.getParsedResponse();
 
@@ -517,7 +517,7 @@ public class OsuIrcBot extends AbstractIrcBot {
   }
 
   @Override
-  public void onUnknown(UnknownEvent<PircBotX> event) throws Exception {
+  public void onUnknown(UnknownEvent event) throws Exception {
     pinger.handleUnknownEvent(event);
   }
   
@@ -535,7 +535,7 @@ public class OsuIrcBot extends AbstractIrcBot {
     }
   }
   
-  void respond(PrivateMessageEvent<?> event, String response) {
+  void respond(PrivateMessageEvent event, String response) {
     if (synchronizeThroughPinger(() -> event.respond(response))) {
       log.debug("RESPONDED to {}: {}", event.getUser().getNick(), response);
     }

--- a/osuCelebrity-osu/src/test/java/me/reddev/osucelebrity/osu/OsuIrcBotTest.java
+++ b/osuCelebrity-osu/src/test/java/me/reddev/osucelebrity/osu/OsuIrcBotTest.java
@@ -65,9 +65,9 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   @Mock
   PircBotX bot;
   @Mock
-  Configuration<PircBotX> configuration;
+  Configuration configuration;
   @Mock
-  ListenerManager<PircBotX> listenerManager;
+  ListenerManager listenerManager;
   @Mock
   OsuIrcSettings settings;
   @Mock
@@ -88,7 +88,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
     when(bot.getConfiguration()).thenReturn(configuration);
     when(configuration.getListenerManager()).thenReturn(listenerManager);
     when(user.getNick()).thenReturn("osuIrcUser");
-    
+
     osuIrcUser = osuApi.getUser(user.getNick(), pm, 0);
 
     when(settings.getOsuIrcCommand()).thenReturn("!");
@@ -128,7 +128,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   public void testSelfQueue() throws Exception {
     when(spectator.enqueue(any(), any(), eq(true), any(), eq(true))).thenReturn(EnqueueResult.SUCCESS);
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!spec"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!spec"));
 
     ArgumentCaptor<QueuedPlayer> captor = ArgumentCaptor.forClass(QueuedPlayer.class);
 
@@ -147,7 +147,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
     when(spectator.enqueue(any(), any(), eq(true), any(), eq(true))).thenReturn(
         EnqueueResult.FAILURE);
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!spec"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!spec"));
 
     verify(spectator, only()).enqueue(any(), any(), eq(true),
         eq("osu:" + osuApi.getUser("osuIrcUser", pm, 0L).getUserId()), eq(true));
@@ -159,7 +159,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   public void testSkip() throws Exception {
     osuApi.getUser("osuIrcUser", pm, 0).setPrivilege(Privilege.MOD);
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!forceskip x"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!forceskip x"));
 
     verify(spectator, only()).advanceConditional(any(),
         eq("x"));
@@ -171,7 +171,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   public void testSpecSilent() throws Exception {
     osuApi.getUser("osuIrcUser", pm, 0).setPrivilege(Privilege.MOD);
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!specsilent x"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!specsilent x"));
 
     verify(spectator, only()).performEnqueue(any(),
         eq(new QueuedPlayer(osuApi.getUser("x", pm, 0L), QueueSource.AUTO, 0L)), eq(null), any(),
@@ -180,7 +180,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
 
   @Test
   public void testSkipUnauthorized() throws Exception {
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!forceskip x"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!forceskip x"));
 
     verifyZeroInteractions(spectator);
 
@@ -191,12 +191,12 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   public void testMuting() throws Exception {
     assertTrue(osuApi.getUser("osuIrcUser", pmf.getPersistenceManager(), 0).isAllowsNotifications());
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!mute"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!mute"));
 
     assertFalse(osuApi.getUser("osuIrcUser", pmf.getPersistenceManager(), 0)
         .isAllowsNotifications());
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!unmute"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!unmute"));
 
     assertTrue(osuApi.getUser("osuIrcUser", pmf.getPersistenceManager(), 0).isAllowsNotifications());
   }
@@ -205,20 +205,20 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   public void testOpting() throws Exception {
     assertTrue(osuApi.getUser("osuIrcUser", pmf.getPersistenceManager(), 0).isAllowsSpectating());
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!optout"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!optout"));
 
     assertFalse(osuApi.getUser("osuIrcUser", pmf.getPersistenceManager(), 0).isAllowsSpectating());
     verify(spectator).removeFromQueue(any(),
         eq(osuApi.getUser("osuIrcUser", pmf.getPersistenceManager(), 0)));
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!optin"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!optin"));
 
     assertTrue(osuApi.getUser("osuIrcUser", pmf.getPersistenceManager(), 0).isAllowsSpectating());
   }
 
   @Test
   public void testUserNamesParser() throws Exception {
-    ircBot.onServerResponse(new ServerResponseEvent<PircBotX>(bot, 353,
+    ircBot.onServerResponse(new ServerResponseEvent(bot, 353,
         ":irc.server.net 353 Phyre = #SomeChannel :@me +you them", ImmutableList
             .copyOf(new String[] {"#SomeChannel", "+me @you them"})));
 
@@ -227,19 +227,19 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   
   @Test
   public void testJoinQuit() throws Exception {
-    ircBot.onJoin(new JoinEvent<PircBotX>(bot, channel, user));
+    ircBot.onJoin(new JoinEvent(bot, channel, user, user));
 
     assertTrue(ircBot.getOnlineUsers().contains("osuIrcUser"));
 
-    ircBot.onQuit(new QuitEvent<PircBotX>(bot, new UserChannelDaoSnapshot(bot, null, null, null,
-        null, null, null), new UserSnapshot(user), "no reason"));
+    ircBot.onQuit(new QuitEvent(bot, new UserChannelDaoSnapshot(bot, null, null, null,
+        null, null, null), user, new UserSnapshot(user), "no reason"));
 
     assertFalse(ircBot.getOnlineUsers().contains("osuIrcUser"));
   }
 
   @Test
   public void testQueue() throws Exception {
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!spec thatguy"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!spec thatguy"));
 
     OsuUser requestedUser = osuApi.getUser("thatguy", pmf.getPersistenceManager(), 0);
 
@@ -250,7 +250,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   
   @Test
   public void testQueueWithComment() throws Exception {
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user,
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user,
         "!spec FrenzyLi: because I want to"));
 
     OsuUser requestedUser = osuApi.getUser("FrenzyLi", pmf.getPersistenceManager(), 0);
@@ -262,7 +262,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
 
   @Test
   public void testQueueAlias() throws Exception {
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!vote thatguy"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!vote thatguy"));
 
     OsuUser requestedUser = osuApi.getUser("thatguy", pmf.getPersistenceManager(), 0);
 
@@ -275,7 +275,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   public void testForceSpec() throws Exception {
     osuApi.getUser("osuIrcUser", pm, 0).setPrivilege(Privilege.MOD);
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!forcespec x"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!forcespec x"));
     
     verify(spectator).promote(any(), 
         eq(osuApi.getUser("x", pmf.getPersistenceManagerProxy(), 0)));
@@ -283,7 +283,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   
   @Test
   public void testForceSpecUnauthorized() throws Exception {
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!forcespec x"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!forcespec x"));
     
     verify(spectator, times(0)).promote(any(), 
         eq(osuApi.getUser("x", pmf.getPersistenceManagerProxy(), 0)));
@@ -293,33 +293,33 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   public void testFixClient() throws Exception {
     osuApi.getUser("osuIrcUser", pm, 0).setPrivilege(Privilege.MOD);
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!fix"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!fix"));
     
     verify(osu).restartClient();
   }
   
   @Test
   public void testFixClientUnauthorized() throws Exception {
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!fix"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!fix"));
     
     verify(osu, times(0)).restartClient();
   }
   
   @Test
   public void testGameMode() throws Exception {
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!gamemode ctb"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!gamemode ctb"));
 
     assertEquals(GameModes.CTB, osuApi.getUser("osuIrcUser", pmf.getPersistenceManager(), 0)
         .getGameMode());
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!gamemode taiko"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!gamemode taiko"));
 
     assertEquals(GameModes.TAIKO, osuApi.getUser("osuIrcUser", pmf.getPersistenceManager(), 0)
         .getGameMode());
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!gamemode mania"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!gamemode mania"));
 
     assertEquals(GameModes.MANIA, osuApi.getUser("osuIrcUser", pmf.getPersistenceManager(), 0)
         .getGameMode());
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!gamemode osu"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!gamemode osu"));
 
     assertEquals(GameModes.OSU, osuApi.getUser("osuIrcUser", pmf.getPersistenceManager(), 0)
         .getGameMode());
@@ -361,7 +361,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
     String osuCommandUser = settings.getOsuCommandUser();
     when(user.getNick()).thenReturn(osuCommandUser);
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user,
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user,
         "Stats for (Tillerino)[https://osu.ppy.sh/u/" + tillerino.getUserId() + "] is Playing:"));
 
     verify(spectator).reportStatus(any(),
@@ -378,7 +378,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
     
     when(user.getNick()).thenReturn("admin");
     
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user,
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user,
         "!mod newmod"));
     
     OsuUser mod = osuApi.getUser("newmod", pmf.getPersistenceManager(), 0);
@@ -394,7 +394,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
     
     when(user.getNick()).thenReturn("notadmin");
     
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user,
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user,
         "!mod newmod"));
     
     OsuUser mod = osuApi.getUser("newmod", pmf.getPersistenceManager(), 0);
@@ -413,7 +413,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
     String osuCommandUser = settings.getOsuCommandUser();
     when(user.getNick()).thenReturn(osuCommandUser);
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user,
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user,
         "Stats for (Tillerino)[https://osu.ppy.sh/u/" + tillerino.getUserId() + "] is Playing:"));
 
     verifyNoMoreInteractions(spectator);
@@ -432,7 +432,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
       pm.makePersistent(twitchUser);
     }
     
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user,
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user,
         "!link <LINKSTRING>"));
 
     // there is only on twitch user, so we can grab anything.
@@ -445,7 +445,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   
   @Test
   public void testLinkNotFound() throws Exception {
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user,
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user,
         "!link <LINKSTRING>"));
 
     verify(outputUser).message(OsuResponses.UNKNOWN_LINK);
@@ -472,7 +472,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
       pm.makePersistent(twitchUser);
     }
     
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user,
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user,
         "!link <LINKSTRING>"));
 
     verify(outputUser).message(OsuResponses.ALREADY_LINKED);
@@ -482,7 +482,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   public void testPosition() throws Exception {
     when(spectator.getQueuePosition(any(), eq(osuUser))).thenReturn(69);
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user,
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user,
         "!position " + osuUser.getUserName()));
    
     verify(outputUser).message(String.format(OsuResponses.POSITION, "defaultUser", 69));
@@ -492,7 +492,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   public void testPositionNotInQueue() throws Exception {
     when(spectator.getQueuePosition(any(), eq(osuUser))).thenReturn(-1);
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user,
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user,
         "!position " + osuUser.getUserName()));
    
     verify(outputUser).message(String.format(OsuResponses.NOT_IN_QUEUE, "defaultUser"));
@@ -502,7 +502,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   public void testSelfPosition() throws Exception {
     when(spectator.getQueuePosition(any(), eq(osuApi.getUser("osuIrcUser", pm, 0L)))).thenReturn(420);
     
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user,
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user,
         "!position"));
    
     verify(outputUser).message(String.format(OsuResponses.POSITION, "osuIrcUser", 420));
@@ -512,7 +512,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   public void testSelfPositionNotInQueue() throws Exception {
     when(spectator.getQueuePosition(any(), eq(osuApi.getUser("osuIrcUser", pm, 0L)))).thenReturn(-1);
     
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user,
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user,
         "!position"));
    
     verify(outputUser).message(String.format(OsuResponses.NOT_IN_QUEUE, "osuIrcUser"));
@@ -522,7 +522,7 @@ public class OsuIrcBotTest extends AbstractJDOTest {
   public void testTimedOut() throws Exception {
     osuApi.getUser("osuIrcUser", pm, 0L).setTimeOutUntil(1L);
 
-    ircBot.onPrivateMessage(new PrivateMessageEvent<PircBotX>(bot, user, "!position"));
+    ircBot.onPrivateMessage(new PrivateMessageEvent(bot, user, user, "!position"));
 
     verify(outputUser).message(OsuResponses.TIMED_OUT_CURRENTLY);
   }

--- a/osuCelebrity-parent/pom.xml
+++ b/osuCelebrity-parent/pom.xml
@@ -163,7 +163,7 @@
 			<dependency>
 				<groupId>org.pircbotx</groupId>
 				<artifactId>pircbotx</artifactId>
-				<version>2.0.1</version>
+				<version>2.1</version>
 			</dependency>
 			<dependency>
 				<groupId>com.github.tillerino</groupId>

--- a/osuCelebrity-twitch/src/main/java/me/reddev/osucelebrity/twitch/TwitchIrcBot.java
+++ b/osuCelebrity-twitch/src/main/java/me/reddev/osucelebrity/twitch/TwitchIrcBot.java
@@ -27,7 +27,6 @@ import me.reddev.osucelebrity.osu.OsuUser;
 import me.reddev.osucelebrity.osuapi.OsuApi;
 import me.reddev.osucelebrity.twitchapi.TwitchApi;
 import org.pircbotx.Configuration;
-import org.pircbotx.PircBotX;
 import org.pircbotx.hooks.events.JoinEvent;
 import org.pircbotx.hooks.events.MessageEvent;
 import org.slf4j.Logger;
@@ -51,13 +50,13 @@ import javax.jdo.PersistenceManagerFactory;
 public class TwitchIrcBot extends AbstractIrcBot {
   @FunctionalInterface
   interface CommandHandler {
-    boolean handle(MessageEvent<PircBotX> event, String message, String twitchUserName,
+    boolean handle(MessageEvent event, String message, String twitchUserName,
         PersistenceManager pm) throws UserException, IOException;
   }
 
   @FunctionalInterface
   interface ConfirmedCommandHandler {
-    void handle(MessageEvent<PircBotX> event, String arguments, String twitchUserName,
+    void handle(MessageEvent event, String arguments, String twitchUserName,
         PersistenceManager pm) throws UserException, IOException;
   }
 
@@ -108,13 +107,14 @@ public class TwitchIrcBot extends AbstractIrcBot {
   }
 
   @Override
-  protected Configuration<PircBotX> getConfiguration() {
-    return new Configuration.Builder<PircBotX>()
+  protected Configuration getConfiguration() {
+    return new Configuration.Builder()
             .setName(settings.getTwitchIrcUsername())
             .setLogin(settings.getTwitchIrcUsername())
             .addListener(this)
-            .setServer(settings.getTwitchIrcHost(), settings.getTwitchIrcPort(),
-                settings.getTwitchToken()).setAutoReconnect(true)
+            .addServer(settings.getTwitchIrcHost(), settings.getTwitchIrcPort())
+            .setServerPassword(settings.getTwitchToken())
+            .setAutoReconnect(true)
             .addAutoJoinChannel(settings.getTwitchIrcChannel()).buildConfiguration();
   }
 
@@ -128,7 +128,7 @@ public class TwitchIrcBot extends AbstractIrcBot {
   }
 
   @Override
-  public void onMessage(MessageEvent<PircBotX> event) {
+  public void onMessage(MessageEvent event) {
     String message = event.getMessage();
     // Search through for command calls
     if (!message.startsWith(settings.getTwitchIrcCommand())) {
@@ -155,7 +155,7 @@ public class TwitchIrcBot extends AbstractIrcBot {
     }
   }
 
-  void handleQueue(MessageEvent<PircBotX> event, String targetUser, String requesterNick,
+  void handleQueue(MessageEvent event, String targetUser, String requesterNick,
       PersistenceManager pm) throws UserException, IOException {
     checkTrust(pm, requesterNick);
     
@@ -174,7 +174,7 @@ public class TwitchIrcBot extends AbstractIrcBot {
     trust.checkTrust(pm, twitch.getUser(pm, subject, 60 * 1000L, true));
   }
 
-  boolean handleVote(MessageEvent<PircBotX> event, String message, String twitchUserName,
+  boolean handleVote(MessageEvent event, String message, String twitchUserName,
       PersistenceManager pm) throws UserException, IOException {
     VoteType type = null;
     if (Commands.detect(message, UPVOTE) != null) {
@@ -194,13 +194,13 @@ public class TwitchIrcBot extends AbstractIrcBot {
     return true;
   }
   
-  void requireMod(MessageEvent<PircBotX> event) throws UserException {
+  void requireMod(MessageEvent event) throws UserException {
     if (!twitchApi.isModerator(event.getUser().getNick())) {
       throw new UserException("You're not a mod.");
     }
   }
 
-  void handleAdvance(MessageEvent<PircBotX> event, String message, String twitchUserName,
+  void handleAdvance(MessageEvent event, String message, String twitchUserName,
       PersistenceManager pm) throws UserException, IOException {
     if (spectator.advanceConditional(pm, message)) {
       sendMessage(String.format(TwitchResponses.SKIPPED_FORCE, message, event.getUser()
@@ -208,7 +208,7 @@ public class TwitchIrcBot extends AbstractIrcBot {
     }
   }
   
-  void handleForceSpec(MessageEvent<PircBotX> event, String message, String twitchUserName,
+  void handleForceSpec(MessageEvent event, String message, String twitchUserName,
       PersistenceManager pm) throws UserException, IOException {
     OsuUser ircUser = getUserOrThrow(pm, message, TimeUnit.DAYS.toMillis(1));
     if (spectator.promote(pm, ircUser)) {
@@ -227,7 +227,7 @@ public class TwitchIrcBot extends AbstractIrcBot {
     return ircUser;
   }
   
-  void handlePosition(MessageEvent<PircBotX> event, String message, String twitchUserName,
+  void handlePosition(MessageEvent event, String message, String twitchUserName,
       PersistenceManager pm) throws UserException, IOException {
     OsuUser ircUser = getUserOrThrow(pm, message, 0);
     int position = spectator.getQueuePosition(pm, ircUser);
@@ -240,7 +240,7 @@ public class TwitchIrcBot extends AbstractIrcBot {
     }
   }
   
-  void handleNowPlaying(MessageEvent<PircBotX> event, String message, String twitchUserName,
+  void handleNowPlaying(MessageEvent event, String message, String twitchUserName,
       PersistenceManager pm) throws UserException, IOException {
     QueuedPlayer player = spectator.getCurrentPlayer(pm);
     if (player == null) {
@@ -263,7 +263,7 @@ public class TwitchIrcBot extends AbstractIrcBot {
     event.getChannel().send().message(formatted);
   }
   
-  void handleFixClient(MessageEvent<PircBotX> event, String message, String twitchUserName,
+  void handleFixClient(MessageEvent event, String message, String twitchUserName,
       PersistenceManager pm) throws UserException, IOException {
     try {
       osu.restartClient();
@@ -272,7 +272,7 @@ public class TwitchIrcBot extends AbstractIrcBot {
     }
   }
   
-  void handleBoost(MessageEvent<PircBotX> event, String boostedUser, String twitchUserName,
+  void handleBoost(MessageEvent event, String boostedUser, String twitchUserName,
       PersistenceManager pm) throws UserException, IOException {
     spectator.boost(pm, getUserOrThrow(pm, boostedUser, 0));
 
@@ -280,7 +280,7 @@ public class TwitchIrcBot extends AbstractIrcBot {
         .message(String.format(TwitchResponses.BOOST_QUEUE, boostedUser, event.getUser().getNick()));
   }
   
-  void handleTimeout(MessageEvent<PircBotX> event, String message, String twitchUserName,
+  void handleTimeout(MessageEvent event, String message, String twitchUserName,
       PersistenceManager pm) throws UserException, IOException {
     String[] split = message.split(" ", 2);
     
@@ -293,14 +293,14 @@ public class TwitchIrcBot extends AbstractIrcBot {
         .message(String.format(TwitchResponses.TIMEOUT, timeoutUser.getUserName(), minutes));
   }
   
-  void handleBannedMapsFilter(MessageEvent<PircBotX> event, String message,
+  void handleBannedMapsFilter(MessageEvent event, String message,
       String twitchUserName, PersistenceManager pm) throws UserException, IOException {
     spectator.addBannedMapFilter(pm, message);
 
     event.getChannel().send().message(String.format(TwitchResponses.ADDED_BANNED_MAPS_FILTER));
   }
   
-  void handleGameMode(MessageEvent<PircBotX> event, String message,
+  void handleGameMode(MessageEvent event, String message,
       String twitchUserName, PersistenceManager pm) throws UserException, IOException {
     String[] split = message.split(" ", 2);
 
@@ -321,22 +321,22 @@ public class TwitchIrcBot extends AbstractIrcBot {
     event.getChannel().send().message(Responses.GAME_MODE_CHANGED);
   }
   
-  void handleExtend(MessageEvent<PircBotX> event, String targetUser,
+  void handleExtend(MessageEvent event, String targetUser,
       String twitchUserName, PersistenceManager pm) throws UserException, IOException {
     spectator.extendConditional(pm, targetUser);
   }
 
-  void handleFreeze(MessageEvent<PircBotX> event, String message,
+  void handleFreeze(MessageEvent event, String message,
       String twitchUserName, PersistenceManager pm) throws UserException, IOException {
     spectator.setFrozen(true);
   }
 
-  void handleUnfreeze(MessageEvent<PircBotX> event, String message,
+  void handleUnfreeze(MessageEvent event, String message,
       String twitchUserName, PersistenceManager pm) throws UserException, IOException {
     spectator.setFrozen(false);
   }
   
-  void handleLink(MessageEvent<PircBotX> event, String message,
+  void handleLink(MessageEvent event, String message,
       String twitchUserName, PersistenceManager pm) throws UserException, IOException {
     TwitchUser user = twitch.getUser(pm, twitchUserName, 60 * 1000L, true);
     
@@ -350,7 +350,7 @@ public class TwitchIrcBot extends AbstractIrcBot {
         String.format(TwitchResponses.LINK_INSTRUCTIONS, user.getLinkString()));
   }
 
-  void handleReplayCurrent(MessageEvent<PircBotX> event, String message,
+  void handleReplayCurrent(MessageEvent event, String message,
       String twitchUserName, PersistenceManager pm) throws UserException, IOException {
     QueuedPlayer currentPlayer = spectator.getCurrentPlayer(pm);
     if (currentPlayer == null) {
@@ -371,7 +371,7 @@ public class TwitchIrcBot extends AbstractIrcBot {
                 replayLink.toString()));
   }
 
-  void handleReplaySpecific(MessageEvent<PircBotX> event, String targetPlayer,
+  void handleReplaySpecific(MessageEvent event, String targetPlayer,
       String twitchUserName, PersistenceManager pm) throws UserException, IOException {
     QueuedPlayer player;
     try (JDOQuery<QueuedPlayer> query = new JDOQuery<>(pm).select(queuedPlayer).from(queuedPlayer)) {
@@ -401,7 +401,7 @@ public class TwitchIrcBot extends AbstractIrcBot {
   }
 
   @Override
-  public void onJoin(JoinEvent<PircBotX> event) {
+  public void onJoin(JoinEvent event) {
     if (event.getUser().getLogin().equalsIgnoreCase(settings.getTwitchIrcUsername())) {
       // Ask for subscription and admin information
       event.getBot().sendRaw().rawLine("CAP REQ :twitch.tv/membership");

--- a/osuCelebrity-twitch/src/main/java/me/reddev/osucelebrity/twitch/TwitchWhisperBot.java
+++ b/osuCelebrity-twitch/src/main/java/me/reddev/osucelebrity/twitch/TwitchWhisperBot.java
@@ -34,16 +34,17 @@ public class TwitchWhisperBot extends AbstractIrcBot {
 
   
   @Override
-  protected Configuration<PircBotX> getConfiguration() throws Exception {
-    return new Configuration.Builder<PircBotX>().setName(settings.getTwitchIrcUsername())
+  protected Configuration getConfiguration() throws Exception {
+    return new Configuration.Builder().setName(settings.getTwitchIrcUsername())
             .setLogin(settings.getTwitchIrcUsername()).addListener(this)
-            .setServer(settings.getTwitchWhisperIrcHost(), settings.getTwitchWhisperIrcPort(),
-                  settings.getTwitchToken()).setAutoReconnect(false)
+            .addServer(settings.getTwitchWhisperIrcHost(), settings.getTwitchWhisperIrcPort())
+            .setServerPassword(settings.getTwitchToken())
+            .setAutoReconnect(false)
             .addAutoJoinChannel(ROOM).buildConfiguration();
   }
 
   @Override
-  public void onConnect(ConnectEvent<PircBotX> event) throws Exception {
+  public void onConnect(ConnectEvent event) throws Exception {
     super.onConnect(event);
     // Enables whispers to be received
     event.getBot().sendRaw().rawLineNow("CAP REQ :twitch.tv/commands");


### PR DESCRIPTION
this is the start of implementing #62

Lots of things still need to happen/addressed:
* [ ] Apparently internally lots of shit changed in pircbotx, so the tests where broken. Added some shit to make them compile again, not sure if they are as intended now (they prolly are, but better safe than sorry I guess xD)
* [ ] probably every instance of `event.getUser().getNick()` can be replaced with `event.getUserHostmask().getNick()`. `getUser()` triggers a "can be null" warning in IntelliJ for me :stuck_out_tongue: 
* [ ] manual sending of `CAP REQ` commands should be replaced with the new way of doing that
  * Also dont forget to add the "twitch.tv/tags" CAP REQ
* [ ] TMI can gtfo
  * What does TMI stuff do atm? Other than checking if someone is mod.
* [ ] Every event now has access to ircv3-tags, these should be used to check for mod-status
* [ ] `AbstractIrcBot` has some fancy crap to get access to the socket to call close on it. But calling `bot.close()` has **exactly** the same effect (it calls `close()` on the underlying socket), so that `PublicSocketBot` thing can probably go away?
* [ ] Most likely tons of other stuff